### PR TITLE
Fix: Correct ImportError for Blob in multimodal_handler

### DIFF
--- a/ai_services/multimodal_handler.py
+++ b/ai_services/multimodal_handler.py
@@ -9,7 +9,6 @@ import vertexai
 from vertexai.generative_models import (
     GenerativeModel,
     Part,
-    Blob,
     SafetySetting,
     HarmCategory,
     HarmBlockThreshold,


### PR DESCRIPTION
Removes the incorrect import of `Blob` from `vertexai.generative_models`. The `Part.from_data()` method is used for PDF content, which directly handles bytes and does not require a separate `Blob` object instantiation in this context.